### PR TITLE
[FLINK-36286][Connectors/Prometheus] Set up validation workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--
+*Thank you for contributing to the Apache Flink Prometheus Connector - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
+
+## Contribution Checklist
+
+- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
+- Commits should be in the form of "[FLINK-XXXX][Connectors / Prometheus] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number.
+- Each pull request should only have one JIRA issue.
+- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
+-->
+
+## Purpose of the change
+
+*For example: Implements the Datastream API for the Prometheus Sink.*
+
+## Verifying this change
+
+Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
+
+*(Please pick either of the following options)*
+
+This change is a trivial rework / code cleanup without any test coverage.
+
+*(or)*
+
+This change is already covered by existing tests, such as *(please describe tests)*.
+
+*(or)*
+
+This change added tests and can be verified as follows:
+
+*(example:)*
+- *Added integration tests for end-to-end deployment*
+- *Added unit tests*
+- *Manually verified by running the Kinesis connector on a local Flink cluster.*
+
+## Significant changes
+*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
+- [ ] Dependencies have been added or upgraded
+- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
+- [ ] Serializers have been changed
+- [ ] New feature has been introduced
+    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -1,0 +1,86 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+labelPRBasedOnFilePath:
+  component=BuildSystem:
+    - .github/**/*
+    - tools/maven/*
+
+  component=Documentation:
+    - docs/**/*
+
+  component=Connectors/Prometheus:
+    - flink-connector-prometheus/**/*
+    - flink-connector-prometheus-request-signer-amp/**/*
+
+###### IssueLink Adder #################################################################################################
+# Insert Issue (Jira/Github etc) link in PR description based on the Issue ID in PR title.
+insertIssueLinkInPrDescription:
+  # specify the placeholder for the issue link that should be present in the description
+  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
+  matchers:
+    # you can have several matches - for different types of issues
+    # only the first matching entry is replaced
+    jiraIssueMatch:
+      # specify the regexp of issue id that you can find in the title of the PR
+      # the match groups can be used to build the issue id (${1}, ${2}, etc.).
+      titleIssueIdRegexp: \[(FLINK-[0-9]+)\]
+      # the issue link to be added. ${1}, ${2} ... are replaced with the match groups from the
+      # title match (remember to use quotes)
+      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1}/)"
+    docOnlyIssueMatch:
+      titleIssueIdRegexp: \[hotfix\]
+      descriptionIssueLink: "`Hotfix, no JIRA issue`"
+
+###### Title Validator #################################################################################################
+# Verifies if commit/PR titles match the regexp specified
+verifyTitles:
+  # Regular expression that should be matched by titles of commits or PR
+  titleRegexp: ^\[FLINK-[0-9]+\].*$|^\[FLINK-XXXXX\].*$|^\[hotfix].*$
+  # If set to true, it will always check the PR title (as opposed to the individual commits).
+  alwaysUsePrTitle: false
+  # If set to true, it will only check the commit in case there is a single commit.
+  # In case of multiple commits it will check PR title.
+  # This reflects the standard behaviour of Github that for `Squash & Merge` GitHub
+  # uses the PR title rather than commit messages for the squashed commit ¯\_(ツ)_/¯
+  # For single-commit PRs it takes the squashed commit message from the commit as expected.
+  #
+  # If set to false it will check all commit messages. This is useful when you do not squash commits at merge.
+  validateEitherPrOrSingleCommitTitle: true
+  # The title the GitHub status should appear from.
+  statusTitle: "Title Validator"
+  # A custom message to be displayed when the title passes validation.
+  successMessage: "Validation successful!"
+  # A custom message to be displayed when the title fails validation.
+  # Allows insertion of ${type} (commit/PR), ${title} (the title validated) and ${regex} (the titleRegexp above).
+  failureMessage: "Wrong ${type} title: ${title}"
+
+# Various Flags to control behaviour of the "Labeler"
+labelerFlags:
+  # If this flag is changed to 'false', labels would only be added when the PR is first created
+  # and not when existing PR is updated.
+  # The default is 'true' which means the labels would be added when PR is updated even if they
+  # were removed by the user
+  labelOnPRUpdates: true
+
+# Comment to be posted to welcome users when they open their first PR
+firstPRWelcomeComment: >
+  Thanks for opening this pull request! Please check out our contributing guidelines. (https://flink.apache.org/contributing/how-to-contribute.html)
+# Comment to be posted to congratulate user on their first merged PR
+firstPRMergeComment: >
+  Awesome work, congrats on your first merged pull request!

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,0 +1,111 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+on:
+  workflow_call:
+    inputs:
+      flink_url:
+        description: "Url to Flink binary."
+        required: true
+        type: string
+      flink_version:
+        description: "Flink version to test against."
+        required: true
+        type: string
+      jdk_version:
+        description: "Jdk version to test against."
+        required: false
+        default: 8, 11
+        type: string
+      cache_flink_binary:
+        description: "Whether to cache the Flink binary. Should be false for SNAPSHOT URLs, true otherwise."
+        required: true
+        type: boolean
+      timeout_global:
+        description: "The timeout in minutes for the entire workflow."
+        required: false
+        type: number
+        default: 60
+      timeout_test:
+        description: "The timeout in minutes for the compile and test step."
+        required: false
+        type: number
+        default: 50
+
+jobs:
+  compile_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: ${{ fromJSON(format('[{0}]', inputs.jdk_version)) }}
+    timeout-minutes: ${{ inputs.timeout_global }}
+    env:
+      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }}
+      MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+      FLINK_CACHE_DIR: "/tmp/cache/flink"
+      MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
+      MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"
+    steps:
+      - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
+
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Set JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set Maven 3.8.5
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.5
+
+      - name: Create cache dirs
+        run: mkdir -p ${{ env.FLINK_CACHE_DIR }}
+
+      - name: Cache Flink binary
+        if: ${{ inputs.cache_flink_binary }}
+        uses: actions/cache@v3
+        id: cache-flink
+        with:
+          path: ${{ env.FLINK_CACHE_DIR }}
+          key: ${{ inputs.flink_url }}
+
+      - name: Download Flink binary
+        working-directory: ${{ env.FLINK_CACHE_DIR }}
+        if: steps.cache-flink.outputs.cache-hit != 'true'
+        run: wget -q -c ${{ inputs.flink_url }} -O - | tar -xz
+
+      - name: Compile and test flink-connector-prometheus
+        timeout-minutes: ${{ inputs.timeout_test }}
+        run: |
+          set -o pipefail
+
+          mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
+            -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
+            -Dflink.version=${{ inputs.flink_version }} | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
+
+      - name: Check licensing
+        run: |
+          mvn ${MVN_COMMON_OPTIONS} exec:java@check-license -N \
+            -Dexec.args="${{ env.MVN_BUILD_OUTPUT_FILE }} $(pwd) $(pwd)" \
+            ${{ env.MVN_CONNECTION_OPTIONS }} \
+            -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,37 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+name: "flink-connector-prometheus: nightly build"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  compile_and_test:
+    if: github.repository_owner == 'apache'
+    strategy:
+      matrix:
+        flink: [1.19-SNAPSHOT, 1.20-SNAPSHOT]
+        java: [ '8, 11, 17']
+    uses: ./.github/workflows/common.yml
+    with:
+      flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}
+      flink_url: https://s3.amazonaws.com/flink-nightly/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
+      cache_flink_binary: false
+    secrets: inherit
+

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -1,0 +1,36 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+name: "flink-connector-prometheus: build on pull request"
+on: [push, pull_request, workflow_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  compile_and_test:
+    uses: ./.github/workflows/common.yml
+    strategy:
+      matrix:
+        flink: [1.19.1, 1.20.0]
+        java: [ '8, 11, 17']
+    with:
+      flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.java }}
+      flink_url: https://archive.apache.org/dist/flink/flink-${{ matrix.flink }}/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
+      cache_flink_binary: true
+    secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@ under the License.
         <flink.version>1.19.1</flink.version>
         <protobuf.version>3.22.2</protobuf.version>
         <apache.httpclient.version>5.2.1</apache.httpclient.version>
+        <jackson-bom.version>2.14.3</jackson-bom.version>
         <log4j.version>2.17.1</log4j.version>
         <junit5.version>5.8.1</junit5.version>
         <aws.sdkv2.version>2.25.69</aws.sdkv2.version>
@@ -65,12 +66,87 @@ under the License.
 
     <dependencyManagement>
         <dependencies>
+            <!--    For dependency convergence    -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>${junit5.version}</version>
-                <scope>test</scope>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>1.3.9</version>
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.15.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.36</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${apache.httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${apache.httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.esotericsoftware.kryo</groupId>
+                <artifactId>kryo</artifactId>
+                <version>2.24.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>2.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit5.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <type>pom</type>
+                <scope>import</scope>
+                <version>${jackson-bom.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdkv2.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Purpose of the change

- Set up Github validation workflows on PR and nightly
- Set up boring-cyborg for PR formatting validation
- Set up PR template

## Verifying this change

- We can verify this change by using this PR as an example for PR template
- We can verify the workflow setup using my personal repo : https://github.com/hlteoh37/flink-connector-prometheus/commits/FLINK-36286

## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
