### PR TITLE
[FLINK-36286][Connectors/Prometheus] Always handle 403 and 404 as fatal errors

### DIFF
--- a/flink-connector-prometheus/README.md
+++ b/flink-connector-prometheus/README.md
@@ -218,6 +218,12 @@ Prometheus does not return sufficient information to automatically handle partia
 > restart from checkpoint. The reason is that restarting from checkpoint cause some duplicates, that are rejected by
 > Prometheus as out of order, causing in turn another non-retriable error, in an endless loop.
 
+
+### Fatal errors
+
+Remote-write endpoint responses 403 (Forbidden) and 404 (Not found) are always considered fatal, regardless the error 
+handling configuration.
+
 ### Metrics
 
 The sink exposes custom metrics, counting the samples and write-requests (batches) successfully written or discarded.

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/HttpResponseCallback.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/HttpResponseCallback.java
@@ -105,6 +105,17 @@ class HttpResponseCallback implements FutureCallback<SimpleHttpResponse> {
         int statusCode = response.getCode();
         String reasonPhrase = response.getReasonPhrase();
 
+        // Prometheus's response is a fatal error, regardless of configured behaviour
+        if (RemoteWriteResponseClassifier.isFatalErrorResponse(response)) {
+            throw new PrometheusSinkWriteException(
+                    "Fatal error response from Prometheus",
+                    statusCode,
+                    reasonPhrase,
+                    timeSeriesCount,
+                    sampleCount,
+                    responseBody);
+        }
+
         // Prometheus's response is a non-retriable error.
         // Depending on the configured behaviour, log and discard or throw an exception
         if (RemoteWriteResponseClassifier.isNonRetriableErrorResponse(response)) {

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifier.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifier.java
@@ -31,11 +31,23 @@ public class RemoteWriteResponseClassifier {
 
     public static boolean isNonRetriableErrorResponse(HttpResponse response) {
         int statusCode = response.getCode();
-        return (statusCode >= 400 && statusCode < 500) && statusCode != 429;
+        return (statusCode >= 400 && statusCode < 500)
+                && statusCode != 429
+                && !isFatalErrorResponse(response);
     }
 
     public static boolean isSuccessResponse(HttpResponse response) {
         int statusCode = response.getCode();
         return (statusCode >= 200 && statusCode < 300);
+    }
+
+    public static boolean isFatalErrorResponse(HttpResponse response) {
+        int statusCode = response.getCode();
+        switch (statusCode) {
+            case 403:
+            case 404:
+                return true;
+        }
+        return false;
     }
 }

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/HttpResponseCallbackTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/HttpResponseCallbackTest.java
@@ -86,7 +86,7 @@ class HttpResponseCallbackTest {
     }
 
     @Test
-    void shouldIncFailCountersOnCompletedWith404WhenDiscardAndContinueOnNonRetriableIsSelected() {
+    void shouldIncFailCountersOnCompletedWith400WhenDiscardAndContinueOnNonRetriableIsSelected() {
         PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
                 errorHandlingBehavior =
                         PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
@@ -104,7 +104,7 @@ class HttpResponseCallbackTest {
                         errorHandlingBehavior,
                         requestResults);
 
-        SimpleHttpResponse httpResponse = new SimpleHttpResponse(HttpStatus.SC_NOT_FOUND);
+        SimpleHttpResponse httpResponse = new SimpleHttpResponse(HttpStatus.SC_BAD_REQUEST);
 
         callback.completed(httpResponse);
 
@@ -176,21 +176,36 @@ class HttpResponseCallbackTest {
 
     @Test
     void shouldThrowExceptionOnCompletedWith100() {
-        PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
-                errorHandlingBehavior =
-                        PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
-                                .builder()
-                                .build();
-
         HttpResponseCallback callback =
                 new HttpResponseCallback(
                         TIME_SERIES_COUNT,
                         SAMPLE_COUNT,
                         metricsCallback,
-                        errorHandlingBehavior,
+                        PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
+                                .DEFAULT_BEHAVIORS,
                         requestResults);
 
         SimpleHttpResponse httpResponse = new SimpleHttpResponse(100);
+
+        assertThrows(
+                PrometheusSinkWriteException.class,
+                () -> {
+                    callback.completed(httpResponse);
+                });
+    }
+
+    @Test
+    void shouldThrowExceptionOnCompletedWith403() {
+        HttpResponseCallback callback =
+                new HttpResponseCallback(
+                        TIME_SERIES_COUNT,
+                        SAMPLE_COUNT,
+                        metricsCallback,
+                        PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
+                                .DEFAULT_BEHAVIORS,
+                        requestResults);
+
+        SimpleHttpResponse httpResponse = new SimpleHttpResponse(403);
 
         assertThrows(
                 PrometheusSinkWriteException.class,

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifierTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifierTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.prometheus.sink.http;
+
+import org.apache.hc.core5.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.connector.prometheus.sink.http.HttpClientTestUtils.httpResponse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RemoteWriteResponseClassifierTest {
+    @Test
+    void shouldClassify200AsSuccess() {
+        HttpResponse response = httpResponse(200);
+
+        assertTrue(RemoteWriteResponseClassifier.isSuccessResponse(response));
+
+        assertFalse(RemoteWriteResponseClassifier.isFatalErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isNonRetriableErrorResponse(response));
+    }
+
+    @Test
+    void shouldClassify400AsNonRetriableError() {
+        HttpResponse response = httpResponse(400);
+
+        assertTrue(RemoteWriteResponseClassifier.isNonRetriableErrorResponse(response));
+
+        assertFalse(RemoteWriteResponseClassifier.isFatalErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isSuccessResponse(response));
+    }
+
+    @Test
+    void shouldClassify403AsFatal() {
+        HttpResponse response = httpResponse(403);
+
+        assertTrue(RemoteWriteResponseClassifier.isFatalErrorResponse(response));
+
+        assertFalse(RemoteWriteResponseClassifier.isNonRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isSuccessResponse(response));
+    }
+
+    @Test
+    void shouldClassify404AsFatal() {
+        HttpResponse response = httpResponse(404);
+
+        assertTrue(RemoteWriteResponseClassifier.isFatalErrorResponse(response));
+
+        assertFalse(RemoteWriteResponseClassifier.isNonRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isSuccessResponse(response));
+    }
+
+    @Test
+    void shouldClassify429AsRetrialeError() {
+        HttpResponse response = httpResponse(429);
+
+        assertTrue(RemoteWriteResponseClassifier.isRetriableErrorResponse(response));
+
+        assertFalse(RemoteWriteResponseClassifier.isNonRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isFatalErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isSuccessResponse(response));
+    }
+
+    @Test
+    void shouldClassify500AsRetriableError() {
+        HttpResponse response = httpResponse(500);
+
+        assertTrue(RemoteWriteResponseClassifier.isRetriableErrorResponse(response));
+
+        assertFalse(RemoteWriteResponseClassifier.isNonRetriableErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isFatalErrorResponse(response));
+        assertFalse(RemoteWriteResponseClassifier.isSuccessResponse(response));
+    }
+}


### PR DESCRIPTION
## Purpose of the change

Fix unfriendly confusing when authentication or endpoint URL are misconfigured, causing 403 or 404 responses. The connector should always fail in this cases.

## Verifying this change

Added unit tests and stack IT

## Significant changes

None