### PR TITLE
[FLINK-36603][Connectors/Prometheus] Fixed spelling of "retryable" and "behavior"

### DIFF
--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/PrometheusSinkBuilder.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/PrometheusSinkBuilder.java
@@ -102,7 +102,7 @@ public class PrometheusSinkBuilder
                         + "\n\t\tmaxTimeInBufferMs={}\n\t\tmaxInFlightRequests={}\n\t\tmaxBufferedRequests={}"
                         + "\n\t\tRetryConfiguration: initialRetryDelayMs={}, maxRetryDelayMs={}, maxRetryCount={}"
                         + "\n\t\tsocketTimeoutMs={}\n\t\thttpUserAgent={}"
-                        + "\n\t\tErrorHandlingBehaviour: onMaxRetryExceeded={}, onNonRetriableError={}",
+                        + "\n\t\tErrorHandlingBehavior: onMaxRetryExceeded={}, onNonRetryableError={}",
                 actualMaxBatchSizeInSamples,
                 actualMaxRecordSizeInSamples,
                 actualMaxTimeInBufferMS,
@@ -114,7 +114,7 @@ public class PrometheusSinkBuilder
                 socketTimeoutMs,
                 actualHttpUserAgent,
                 actualErrorHandlingBehaviorConfig.getOnMaxRetryExceeded(),
-                actualErrorHandlingBehaviorConfig.getOnPrometheusNonRetriableError());
+                actualErrorHandlingBehaviorConfig.getOnPrometheusNonRetryableError());
 
         return new PrometheusSink(
                 new PrometheusTimeSeriesConverter(),
@@ -168,7 +168,7 @@ public class PrometheusSinkBuilder
         return this;
     }
 
-    public PrometheusSinkBuilder setErrorHandlingBehaviourConfiguration(
+    public PrometheusSinkBuilder setErrorHandlingBehaviorConfiguration(
             PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
                     errorHandlingBehaviorConfig) {
         this.errorHandlingBehaviorConfig = errorHandlingBehaviorConfig;

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/PrometheusSinkConfiguration.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/PrometheusSinkConfiguration.java
@@ -31,7 +31,7 @@ import static org.apache.flink.connector.prometheus.sink.PrometheusSinkConfigura
 public class PrometheusSinkConfiguration {
 
     /**
-     * Defines the behaviour when an error is encountered: discard the offending request and
+     * Defines the behavior when an error is encountered: discard the offending request and
      * continue, or fail, throwing an exception.
      */
     public enum OnErrorBehavior {
@@ -46,40 +46,40 @@ public class PrometheusSinkConfiguration {
     public static class SinkWriterErrorHandlingBehaviorConfiguration implements Serializable {
 
         public static final OnErrorBehavior ON_MAX_RETRY_EXCEEDED_DEFAULT_BEHAVIOR = FAIL;
-        public static final OnErrorBehavior ON_PROMETHEUS_NON_RETRIABLE_ERROR_DEFAULT_BEHAVIOR =
+        public static final OnErrorBehavior ON_PROMETHEUS_NON_RETRYABLE_ERROR_DEFAULT_BEHAVIOR =
                 DISCARD_AND_CONTINUE;
 
-        /** Behaviour when the max retries is exceeded on Prometheus retriable errors. */
+        /** Behavior when the max retries is exceeded on Prometheus retryable errors. */
         private final OnErrorBehavior onMaxRetryExceeded;
 
-        /** Behaviour when Prometheus Remote-Write respond with a non-retriable error. */
-        private final OnErrorBehavior onPrometheusNonRetriableError;
+        /** Behavior when Prometheus Remote-Write respond with a non-retryable error. */
+        private final OnErrorBehavior onPrometheusNonRetryableError;
 
         public SinkWriterErrorHandlingBehaviorConfiguration(
-                OnErrorBehavior onMaxRetryExceeded, OnErrorBehavior onPrometheusNonRetriableError) {
-            // onPrometheusNonRetriableError cannot be set to FAIL, because it makes impossible for
+                OnErrorBehavior onMaxRetryExceeded, OnErrorBehavior onPrometheusNonRetryableError) {
+            // onPrometheusNonRetryableError cannot be set to FAIL, because it makes impossible for
             // the job to restart from checkpoint (see FLINK-36319).
             // We are retaining the possibility of configuring the behavior on this type of error to
             // allow implementing a different type of behavior.
             Preconditions.checkArgument(
-                    onPrometheusNonRetriableError == DISCARD_AND_CONTINUE,
-                    "Only DISCARD_AND_CONTINUE is currently supported for onPrometheusNonRetriableError");
+                    onPrometheusNonRetryableError == DISCARD_AND_CONTINUE,
+                    "Only DISCARD_AND_CONTINUE is currently supported for onPrometheusNonRetryableError");
             this.onMaxRetryExceeded = onMaxRetryExceeded;
-            this.onPrometheusNonRetriableError = onPrometheusNonRetriableError;
+            this.onPrometheusNonRetryableError = onPrometheusNonRetryableError;
         }
 
         public OnErrorBehavior getOnMaxRetryExceeded() {
             return onMaxRetryExceeded;
         }
 
-        public OnErrorBehavior getOnPrometheusNonRetriableError() {
-            return onPrometheusNonRetriableError;
+        public OnErrorBehavior getOnPrometheusNonRetryableError() {
+            return onPrometheusNonRetryableError;
         }
 
         /** Builder for PrometheusSinkWriterErrorHandlingConfiguration. */
         public static class Builder {
             private OnErrorBehavior onMaxRetryExceeded = null;
-            private OnErrorBehavior onPrometheusNonRetriableError = null;
+            private OnErrorBehavior onPrometheusNonRetryableError = null;
 
             public Builder() {}
 
@@ -88,8 +88,8 @@ public class PrometheusSinkConfiguration {
                 return this;
             }
 
-            public Builder onPrometheusNonRetriableError(OnErrorBehavior onErrorBehavior) {
-                this.onPrometheusNonRetriableError = onErrorBehavior;
+            public Builder onPrometheusNonRetryableError(OnErrorBehavior onErrorBehavior) {
+                this.onPrometheusNonRetryableError = onErrorBehavior;
                 return this;
             }
 
@@ -97,8 +97,8 @@ public class PrometheusSinkConfiguration {
                 return new SinkWriterErrorHandlingBehaviorConfiguration(
                         Optional.ofNullable(onMaxRetryExceeded)
                                 .orElse(ON_MAX_RETRY_EXCEEDED_DEFAULT_BEHAVIOR),
-                        Optional.ofNullable(onPrometheusNonRetriableError)
-                                .orElse(ON_PROMETHEUS_NON_RETRIABLE_ERROR_DEFAULT_BEHAVIOR));
+                        Optional.ofNullable(onPrometheusNonRetryableError)
+                                .orElse(ON_PROMETHEUS_NON_RETRYABLE_ERROR_DEFAULT_BEHAVIOR));
             }
         }
 

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifier.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifier.java
@@ -22,8 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.hc.core5.http.HttpResponse;
 
 import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.FATAL_ERROR;
-import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.NON_RETRIABLE_ERROR;
-import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.RETRIABLE_ERROR;
+import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.NON_RETRYABLE_ERROR;
+import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.RETRYABLE_ERROR;
 import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.SUCCESS;
 import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.UNHANDLED;
 
@@ -38,17 +38,17 @@ public class RemoteWriteResponseClassifier {
             return SUCCESS;
         } else if (statusCode == 429) {
             // 429, Too Many Requests: throttling
-            return RETRIABLE_ERROR;
+            return RETRYABLE_ERROR;
         } else if (statusCode == 403 || statusCode == 404) {
             // 403, Forbidden: authentication error
             // 404, Not Found: wrong endpoint URL path
             return FATAL_ERROR;
         } else if (statusCode >= 400 && statusCode < 500) {
             // 4xx (except 403, 404, 429): wrong request/bad data
-            return NON_RETRIABLE_ERROR;
+            return NON_RETRYABLE_ERROR;
         } else if (statusCode >= 500) {
             // 5xx: internal errors, recoverable
-            return RETRIABLE_ERROR;
+            return RETRYABLE_ERROR;
         } else {
             // Other status code are unhandled
             return UNHANDLED;

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseType.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseType.java
@@ -28,12 +28,12 @@ public enum RemoteWriteResponseType {
     /** The Write-Request was successfully accepted. */
     SUCCESS,
     /** Write-Request temporarily rejected. The request can be retried. */
-    RETRIABLE_ERROR,
+    RETRYABLE_ERROR,
     /**
      * Write-Request permanently rejected. It cannot be retried. The error condition is recoverable,
      * after discarding the offending request.
      */
-    NON_RETRIABLE_ERROR,
+    NON_RETRYABLE_ERROR,
     /** Unrecoverable error condition. */
     FATAL_ERROR,
     /** Unhandled status code. */

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteRetryStrategy.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteRetryStrategy.java
@@ -41,7 +41,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseClassifier.classify;
-import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.RETRIABLE_ERROR;
+import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.RETRYABLE_ERROR;
 
 /**
  * Retry strategy for the http client.
@@ -49,10 +49,10 @@ import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteRespons
  * <p>Based on the http status code returned or the exception thrown, this strategy either retries
  * with an exponential backoff strategy or immediately fail.
  *
- * <p>Response status codes are classified as retriable or non-retriable using {@link
+ * <p>Response status codes are classified as retryable or non-retryable using {@link
  * RemoteWriteResponseClassifier}.
  *
- * <p>All {@link IOException} are considered retriable, except for {@link InterruptedIOException},
+ * <p>All {@link IOException} are considered retryable, except for {@link InterruptedIOException},
  * {@link UnknownHostException}, {@link ConnectException}, {@link NoRouteToHostException}, and
  * {@link SSLException}.
  */
@@ -60,7 +60,7 @@ import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteRespons
 public class RemoteWriteRetryStrategy implements HttpRequestRetryStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(RemoteWriteRetryStrategy.class);
 
-    /** List of exceptions considered non-recoverable (non-retriable). */
+    /** List of exceptions considered non-recoverable (non-retryable). */
     private static final List<Class<? extends IOException>> NON_RECOVERABLE_EXCEPTIONS =
             Collections.unmodifiableList(
                     new ArrayList<Class<? extends IOException>>() {
@@ -106,7 +106,7 @@ public class RemoteWriteRetryStrategy implements HttpRequestRetryStrategy {
 
     @Override
     public boolean retryRequest(HttpResponse httpResponse, int execCount, HttpContext httpContext) {
-        boolean retry = (execCount <= maxRetryCount) && (classify(httpResponse) == RETRIABLE_ERROR);
+        boolean retry = (execCount <= maxRetryCount) && (classify(httpResponse) == RETRYABLE_ERROR);
         LOG.debug(
                 "{} retry on response {} {}, at execution {}",
                 (retry) ? "DO" : "DO NOT",

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/metrics/SinkMetrics.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/metrics/SinkMetrics.java
@@ -52,15 +52,15 @@ public class SinkMetrics {
     /** Enum defining all sink counters. */
     public enum SinkCounter {
 
-        /** Total number of Samples that were dropped because of causing non-retriable errors. */
-        NUM_SAMPLES_NON_RETRIABLE_DROPPED("numSamplesNonRetriableDropped"),
+        /** Total number of Samples that were dropped because of causing non-retryable errors. */
+        NUM_SAMPLES_NON_RETRYABLE_DROPPED("numSamplesNonRetryableDropped"),
 
-        /** Number of Samples dropped after reaching retry limit on retriable errors. */
+        /** Number of Samples dropped after reaching retry limit on retryable errors. */
         NUM_SAMPLES_RETRY_LIMIT_DROPPED("numSamplesRetryLimitDropped"),
 
         /**
-         * Total number of Samples dropped due to any reasons: retriable errors reaching retry
-         * limit, non-retriable errors, unexpected IO errors.
+         * Total number of Samples dropped due to any reasons: retryable errors reaching retry
+         * limit, non-retryable errors, unexpected IO errors.
          */
         NUM_SAMPLES_DROPPED("numSamplesDropped"),
 

--- a/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/metrics/SinkMetricsCallback.java
+++ b/flink-connector-prometheus/src/main/java/org/apache/flink/connector/prometheus/sink/metrics/SinkMetricsCallback.java
@@ -21,7 +21,7 @@ package org.apache.flink.connector.prometheus.sink.metrics;
 import org.apache.flink.annotation.Internal;
 
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_DROPPED;
-import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_NON_RETRIABLE_DROPPED;
+import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_NON_RETRYABLE_DROPPED;
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_OUT;
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_RETRY_LIMIT_DROPPED;
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_WRITE_REQUESTS_OUT;
@@ -52,8 +52,8 @@ public class SinkMetricsCallback {
         metrics.inc(NUM_WRITE_REQUESTS_OUT);
     }
 
-    public void onFailedWriteRequestForNonRetriableError(long sampleCount) {
-        metrics.inc(NUM_SAMPLES_NON_RETRIABLE_DROPPED, sampleCount);
+    public void onFailedWriteRequestForNonRetryableError(long sampleCount) {
+        metrics.inc(NUM_SAMPLES_NON_RETRYABLE_DROPPED, sampleCount);
         onFailedWriteRequest(sampleCount);
     }
 

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/HttpResponseCallbackTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/HttpResponseCallbackTest.java
@@ -72,10 +72,10 @@ class HttpResponseCallbackTest {
     }
 
     @Test
-    void shouldIncFailCountersOnCompletedWith400WhenDiscardAndContinueOnNonRetriableIsSelected() {
+    void shouldIncFailCountersOnCompletedWith400WhenDiscardAndContinueOnNonRetryableIsSelected() {
         SinkWriterErrorHandlingBehaviorConfiguration errorHandlingBehavior =
                 SinkWriterErrorHandlingBehaviorConfiguration.builder()
-                        .onPrometheusNonRetriableError(
+                        .onPrometheusNonRetryableError(
                                 PrometheusSinkConfiguration.OnErrorBehavior.DISCARD_AND_CONTINUE)
                         .build();
 
@@ -93,7 +93,7 @@ class HttpResponseCallbackTest {
 
         // Verify only the expected metrics callback was called, once
         assertTrue(
-                metricsCallback.verifyOnlyFailedWriteRequestsForNonRetriableErrorWasCalledOnce());
+                metricsCallback.verifyOnlyFailedWriteRequestsForNonRetryableErrorWasCalledOnce());
 
         // No time series is re-queued
         HttpResponseCallbackTestUtils.assertNoReQueuedResult(reQueuedResults);

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/HttpResponseHandlingBehaviorIT.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/HttpResponseHandlingBehaviorIT.java
@@ -48,20 +48,20 @@ import static org.apache.flink.connector.prometheus.sink.HttpResponseCallbackTes
 import static org.awaitility.Awaitility.await;
 
 /**
- * Test the http response handling behaviour with the full stack handling http client, retries and
+ * Test the http response handling behavior with the full stack handling http client, retries and
  * error handling.
  *
- * <p>The full behaviour is determined by the combination of {@link HttpResponseCallback}, {@link
+ * <p>The full behavior is determined by the combination of {@link HttpResponseCallback}, {@link
  * org.apache.flink.connector.prometheus.sink.http.RemoteWriteRetryStrategy}, {@link
  * PrometheusSinkConfiguration.RetryConfiguration}, {@link
  * org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseClassifier}, and {@link
  * PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration}.
  *
- * <p>The behaviour of the stack is tested sending a request through the http client and simulating
+ * <p>The behavior of the stack is tested sending a request through the http client and simulating
  * the response from Prometheus using a WireMock stub.
  */
 @WireMockTest
-public class HttpResponseHandlingBehaviourIT {
+public class HttpResponseHandlingBehaviorIT {
 
     private static final int TIME_SERIES_COUNT = 13;
     private static final long SAMPLE_COUNT = 42;
@@ -140,7 +140,7 @@ public class HttpResponseHandlingBehaviourIT {
         int maxRetryCount = 2;
         PrometheusAsyncHttpClientBuilder clientBuilder = getHttpClientBuilder(maxRetryCount);
 
-        // 500,Server error is retriable for Prometheus remote-write
+        // 500,Server error is retryable for Prometheus remote-write
         int statusCode = 500;
         serverWillRespond(status(statusCode));
 
@@ -182,7 +182,7 @@ public class HttpResponseHandlingBehaviourIT {
         int maxRetryCount = 2;
         PrometheusAsyncHttpClientBuilder clientBuilder = getHttpClientBuilder(maxRetryCount);
 
-        // 500,Server error is retriable for Prometheus remote-write
+        // 500,Server error is retryable for Prometheus remote-write
         int statusCode = 500;
         serverWillRespond(status(statusCode));
 
@@ -219,20 +219,20 @@ public class HttpResponseHandlingBehaviourIT {
     }
 
     @Test
-    void shouldNotRetryAndCompleteOn400WhenDiscardAndContinueOnNonRetriableIsSelected(
+    void shouldNotRetryAndCompleteOn400WhenDiscardAndContinueOnNonRetryableIsSelected(
             WireMockRuntimeInfo wmRuntimeInfo) throws URISyntaxException, IOException {
         PrometheusAsyncHttpClientBuilder clientBuilder = getHttpClientBuilder(1);
 
-        // 400,Bad Request is non-retriable for Prometheus remote-write
+        // 400,Bad Request is non-retryable for Prometheus remote-write
         int statusCode = 400;
         serverWillRespond(status(statusCode));
 
-        // Discard and continue on non-retriable
+        // Discard and continue on non-retryable
         PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
                 errorHandlingBehavior =
                         PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
                                 .builder()
-                                .onPrometheusNonRetriableError(
+                                .onPrometheusNonRetryableError(
                                         PrometheusSinkConfiguration.OnErrorBehavior
                                                 .DISCARD_AND_CONTINUE)
                                 .build();
@@ -260,7 +260,7 @@ public class HttpResponseHandlingBehaviourIT {
     void shouldNotRetryCompleteAndThrowExceptionOn304(WireMockRuntimeInfo wmRuntimeInfo)
             throws URISyntaxException, IOException {
 
-        // 304, Not modified is just status code for which the behaviour is not
+        // 304, Not modified is just status code for which the behavior is not
         // specified by Prometheus remote-write specs, and makes the http client
         // terminate successfully
         int statusCode = 304;

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/PrometheusSinkBuilderTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/PrometheusSinkBuilderTest.java
@@ -48,14 +48,14 @@ class PrometheusSinkBuilderTest {
                                 .setSocketTimeoutMs(1000)
                                 .setRequestSigner(new DummyPrometheusRequestSigner())
                                 .setHttpUserAgent("test")
-                                .setErrorHandlingBehaviourConfiguration(
+                                .setErrorHandlingBehaviorConfiguration(
                                         PrometheusSinkConfiguration
                                                 .SinkWriterErrorHandlingBehaviorConfiguration
                                                 .builder()
                                                 .onMaxRetryExceeded(
                                                         PrometheusSinkConfiguration.OnErrorBehavior
                                                                 .FAIL)
-                                                .onPrometheusNonRetriableError(
+                                                .onPrometheusNonRetryableError(
                                                         PrometheusSinkConfiguration.OnErrorBehavior
                                                                 .DISCARD_AND_CONTINUE)
                                                 .build())

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/SinkWriterErrorHandlingBehaviorConfigurationTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/SinkWriterErrorHandlingBehaviorConfigurationTest.java
@@ -38,20 +38,20 @@ class SinkWriterErrorHandlingBehaviorConfigurationTest {
     }
 
     @Test
-    public void shouldDefaultToDiscardAndContinueOnPrometheusNonRetriableError() {
+    public void shouldDefaultToDiscardAndContinueOnPrometheusNonRetryableError() {
         assertEquals(
                 PrometheusSinkConfiguration.OnErrorBehavior.DISCARD_AND_CONTINUE,
-                DEFAULT_CONFIG.getOnPrometheusNonRetriableError());
+                DEFAULT_CONFIG.getOnPrometheusNonRetryableError());
     }
 
     @Test
-    public void shouldPreventSettingContinueOnPrometheusNonRetriableErrorToFail() {
+    public void shouldPreventSettingContinueOnPrometheusNonRetryableErrorToFail() {
         assertThrows(
                 IllegalArgumentException.class,
                 () ->
                         PrometheusSinkConfiguration.SinkWriterErrorHandlingBehaviorConfiguration
                                 .builder()
-                                .onPrometheusNonRetriableError(
+                                .onPrometheusNonRetryableError(
                                         PrometheusSinkConfiguration.OnErrorBehavior.FAIL)
                                 .build());
     }

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/examples/DataStreamExample.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/examples/DataStreamExample.java
@@ -132,7 +132,7 @@ public class DataStreamExample {
                         .setSocketTimeoutMs(5000) // Optional, default 5000 ms
                         // If no Error Handling Behavior configuration is provided, all behaviors
                         // default to FAIL
-                        .setErrorHandlingBehaviourConfiguration(
+                        .setErrorHandlingBehaviorConfiguration(
                                 PrometheusSinkConfiguration
                                         .SinkWriterErrorHandlingBehaviorConfiguration.builder()
                                         .onMaxRetryExceeded(

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifierTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteResponseClassifierTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.connector.prometheus.sink.http.HttpClientTestUtils.httpResponse;
 import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.FATAL_ERROR;
-import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.NON_RETRIABLE_ERROR;
-import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.RETRIABLE_ERROR;
+import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.NON_RETRYABLE_ERROR;
+import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.RETRYABLE_ERROR;
 import static org.apache.flink.connector.prometheus.sink.http.RemoteWriteResponseType.UNHANDLED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -43,10 +43,10 @@ public class RemoteWriteResponseClassifierTest {
     }
 
     @Test
-    void shouldClassify400AsNonRetriableError() {
+    void shouldClassify400AsNonRetryableError() {
         HttpResponse response = httpResponse(400);
 
-        assertEquals(NON_RETRIABLE_ERROR, RemoteWriteResponseClassifier.classify(response));
+        assertEquals(NON_RETRYABLE_ERROR, RemoteWriteResponseClassifier.classify(response));
     }
 
     @Test
@@ -64,16 +64,16 @@ public class RemoteWriteResponseClassifierTest {
     }
 
     @Test
-    void shouldClassify429AsRetrialeError() {
+    void shouldClassify429AsRetryableError() {
         HttpResponse response = httpResponse(429);
 
-        assertEquals(RETRIABLE_ERROR, RemoteWriteResponseClassifier.classify(response));
+        assertEquals(RETRYABLE_ERROR, RemoteWriteResponseClassifier.classify(response));
     }
 
     @Test
-    void shouldClassify500AsRetriableError() {
+    void shouldClassify500AsRetryableError() {
         HttpResponse response = httpResponse(500);
 
-        assertEquals(RETRIABLE_ERROR, RemoteWriteResponseClassifier.classify(response));
+        assertEquals(RETRYABLE_ERROR, RemoteWriteResponseClassifier.classify(response));
     }
 }

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteRetryStrategyTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/http/RemoteWriteRetryStrategyTest.java
@@ -54,7 +54,7 @@ class RemoteWriteRetryStrategyTest {
                     .build();
 
     @Test
-    public void shouldRetryOnRetriableErrorResponse() {
+    public void shouldRetryOnRetryableErrorResponse() {
         HttpResponse httpResponse = httpResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         HttpContext httpContext = httpContext();
         VerifybleSinkMetricsCallback metrics = new VerifybleSinkMetricsCallback();
@@ -65,7 +65,7 @@ class RemoteWriteRetryStrategyTest {
     }
 
     @Test
-    public void shouldNotRetryOnNonRetriableErrorResponse() {
+    public void shouldNotRetryOnNonRetryableErrorResponse() {
         HttpResponse httpResponse = httpResponse(HttpStatus.SC_FORBIDDEN);
         HttpContext httpContext = httpContext();
         VerifybleSinkMetricsCallback metricsCallback = new VerifybleSinkMetricsCallback();
@@ -88,7 +88,7 @@ class RemoteWriteRetryStrategyTest {
     }
 
     @Test
-    public void shouldNotRetryNonRetriableIOExceptions() {
+    public void shouldNotRetryNonRetryableIOExceptions() {
         HttpRequest httpRequest = postHttpRequest();
         HttpContext httpContext = httpContext();
         VerifybleSinkMetricsCallback metricsCallback = new VerifybleSinkMetricsCallback();

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/metrics/SinkMetricsCallbackTest.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/metrics/SinkMetricsCallbackTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.connector.prometheus.sink.InspectableMetricGroupAssertions.assertCounterCount;
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_DROPPED;
-import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_NON_RETRIABLE_DROPPED;
+import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_NON_RETRYABLE_DROPPED;
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_OUT;
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_SAMPLES_RETRY_LIMIT_DROPPED;
 import static org.apache.flink.connector.prometheus.sink.metrics.SinkMetrics.SinkCounter.NUM_WRITE_REQUESTS_OUT;
@@ -55,10 +55,10 @@ class SinkMetricsCallbackTest {
     }
 
     @Test
-    void onFailedWriteRequestForNonRetriableError() {
-        metricsCallback.onFailedWriteRequestForNonRetriableError(SAMPLE_COUNT);
+    void onFailedWriteRequestForNonRetryableError() {
+        metricsCallback.onFailedWriteRequestForNonRetryableError(SAMPLE_COUNT);
 
-        assertCounterCount(SAMPLE_COUNT, metricGroup, NUM_SAMPLES_NON_RETRIABLE_DROPPED);
+        assertCounterCount(SAMPLE_COUNT, metricGroup, NUM_SAMPLES_NON_RETRYABLE_DROPPED);
         assertCounterCount(SAMPLE_COUNT, metricGroup, NUM_SAMPLES_DROPPED);
         assertCounterCount(1, metricGroup, NUM_WRITE_REQUESTS_PERMANENTLY_FAILED);
 

--- a/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/metrics/VerifybleSinkMetricsCallback.java
+++ b/flink-connector-prometheus/src/test/java/org/apache/flink/connector/prometheus/sink/metrics/VerifybleSinkMetricsCallback.java
@@ -27,7 +27,7 @@ import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
  */
 public class VerifybleSinkMetricsCallback extends SinkMetricsCallback {
     private int successfulWriteRequestsCount = 0;
-    private int failedWriteRequestForNonRetriableErrorCount = 0;
+    private int failedWriteRequestForNonRetryableErrorCount = 0;
     private int failedWriteRequestForRetryLimitExceededCount = 0;
     private int failedWriteRequestForHttpClientIoFailCount = 0;
     private int writeRequestsRetryCount = 0;
@@ -44,8 +44,8 @@ public class VerifybleSinkMetricsCallback extends SinkMetricsCallback {
     }
 
     @Override
-    public void onFailedWriteRequestForNonRetriableError(long sampleCount) {
-        failedWriteRequestForNonRetriableErrorCount++;
+    public void onFailedWriteRequestForNonRetryableError(long sampleCount) {
+        failedWriteRequestForNonRetryableErrorCount++;
     }
 
     @Override
@@ -65,15 +65,15 @@ public class VerifybleSinkMetricsCallback extends SinkMetricsCallback {
 
     public boolean verifyOnlySuccessfulWriteRequestsWasCalledOnce() {
         return successfulWriteRequestsCount == 1
-                && failedWriteRequestForNonRetriableErrorCount == 0
+                && failedWriteRequestForNonRetryableErrorCount == 0
                 && failedWriteRequestForRetryLimitExceededCount == 0
                 && failedWriteRequestForHttpClientIoFailCount == 0
                 && writeRequestsRetryCount == 0;
     }
 
-    public boolean verifyOnlyFailedWriteRequestsForNonRetriableErrorWasCalledOnce() {
+    public boolean verifyOnlyFailedWriteRequestsForNonRetryableErrorWasCalledOnce() {
         return successfulWriteRequestsCount == 0
-                && failedWriteRequestForNonRetriableErrorCount == 1
+                && failedWriteRequestForNonRetryableErrorCount == 1
                 && failedWriteRequestForRetryLimitExceededCount == 0
                 && failedWriteRequestForHttpClientIoFailCount == 0
                 && writeRequestsRetryCount == 0;
@@ -81,7 +81,7 @@ public class VerifybleSinkMetricsCallback extends SinkMetricsCallback {
 
     public boolean verifyOnlyFailedWriteRequestsForRetryLimitExceededWasCalledOnce() {
         return successfulWriteRequestsCount == 0
-                && failedWriteRequestForNonRetriableErrorCount == 0
+                && failedWriteRequestForNonRetryableErrorCount == 0
                 && failedWriteRequestForRetryLimitExceededCount == 1
                 && failedWriteRequestForHttpClientIoFailCount == 0
                 && writeRequestsRetryCount == 0;
@@ -89,7 +89,7 @@ public class VerifybleSinkMetricsCallback extends SinkMetricsCallback {
 
     public boolean verifyOnlyFailedWriteRequestsForHttpClientIoFailWasCalledOnce() {
         return successfulWriteRequestsCount == 0
-                && failedWriteRequestForNonRetriableErrorCount == 0
+                && failedWriteRequestForNonRetryableErrorCount == 0
                 && failedWriteRequestForRetryLimitExceededCount == 0
                 && failedWriteRequestForHttpClientIoFailCount == 1
                 && writeRequestsRetryCount == 0;
@@ -97,7 +97,7 @@ public class VerifybleSinkMetricsCallback extends SinkMetricsCallback {
 
     public boolean verifyOnlyWriteRequestsRetryWasCalled(int times) {
         return successfulWriteRequestsCount == 0
-                && failedWriteRequestForNonRetriableErrorCount == 0
+                && failedWriteRequestForNonRetryableErrorCount == 0
                 && failedWriteRequestForRetryLimitExceededCount == 0
                 && failedWriteRequestForHttpClientIoFailCount == 0
                 && writeRequestsRetryCount == times;


### PR DESCRIPTION
## Purpose of the change

Fixed spelling of words "behavior" and "retryable" inconsistently used across the code and the API

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
