### PR TITLE
[hotfix][docs] Explicitly set connector compatibility as string to pr…

### DIFF
--- a/docs/data/prometheus.yml
+++ b/docs/data/prometheus.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 1.0.0
-flink_compatibility: [1.19, 1.20]
+flink_compatibility: ["1.19", "1.20"]
 variants:
   - maven: flink-connector-prometheus
   - maven: flink-connector-prometheus-request-signer-amp


### PR DESCRIPTION
…event version comparison mismatch

## Purpose of the change

Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132


## Verifying this change

After fix, the version artifact shows up.

![image](https://github.com/user-attachments/assets/11d40a29-4b61-4d37-9280-54be26f25642)


## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
